### PR TITLE
Added parse_logicals() and parse_not()

### DIFF
--- a/headers/parser.h
+++ b/headers/parser.h
@@ -53,6 +53,16 @@ void apply_children(s_command** commands, int index);
 int condense_subshells(s_command** commands);
 
 /**
+ * Recursively finds NOT symbols and processes them.\n
+ *
+ * Will assign the next element to the NOT left child. The right child
+ * of NOT will be NULL.
+ *
+ * @param commands - an array of commands to loop through
+ */
+void parse_not(s_command** commands);
+
+/**
  * Assigns all remaining elements as left children to one another.\n
  *
  * As such, a left over: 1->2 will become a tree where 2 is the left child of 1.
@@ -61,6 +71,16 @@ int condense_subshells(s_command** commands);
  * @param commands - an array of commands to loop through
  */
 void parse_leftovers(s_command** commands);
+
+/**
+ * Recursively finds logical symbols and processes them.\n
+ *
+ * Logical symbols are processed from left-right, with apply_children()
+ * being called on each occurrence.
+ *
+ * @param commands - an array of commands to loop through
+ */
+void parse_logicals(s_command** commands);
 
 /**
  * Organizes an array of commands into a single tree.\n

--- a/src/parser.c
+++ b/src/parser.c
@@ -80,14 +80,53 @@ void parse_leftovers(s_command** commands) {
     }
 }
 
+void parse_logicals(s_command** commands){
+    if(commands == NULL) crash("parse_logicals() was called with a NULL s_command");
+
+    int index = 0;
+    s_command* current = commands[index];
+    while(current != NULL){
+        switch(current->type){
+            case AND:
+            case OR:
+                apply_children(commands, index);
+                index -= 1;
+            default:
+                break;
+        }
+        index += 1;
+        current = commands[index];
+    }
+}
+
+void parse_not(s_command** commands){
+    if(commands == NULL) crash("parse_not() was called with a NULL s_command");
+
+    int index = 1;
+    s_command* current = commands[0];
+    while(commands[index] != NULL){
+        if(current->type != NOT){
+            current = commands[index];
+            index += 1;
+            continue;
+        }
+        current->left = commands[index];
+        commands[index] = NULL;
+        shift_to_left(&commands[index], 1);
+        current = commands[index];
+        index += 1;
+    }
+}
+
 s_command* parse(s_command** commands){
     condense_subshells(commands);
+    parse_not(commands);
 
     parse_type(commands, PIPE);
     parse_type(commands, REDIRECT_TO);
     parse_type(commands, REDIRECT_TO_OVERWRITE);
+    parse_logicals(commands);
     parse_type(commands, ENDCOMMAND);
-
     parse_leftovers(commands);
 
     return commands[0];

--- a/src/parser.c
+++ b/src/parser.c
@@ -68,6 +68,8 @@ int condense_subshells(s_command** commands){
 }
 
 void parse_leftovers(s_command** commands) {
+    if(commands == NULL) crash("parse_leftovers() was called with a NULL s_command");
+
     int index = 1;
     s_command* current = commands[0];
     while(commands[index] != NULL){


### PR DESCRIPTION
Fixes #1 and #6

NOTs now get parsed right after SUBSHELLs, and the rest of logicals get parsed right before ENDCOMMANDs. Before, all logicals were getting parsed at the end with the rest of the base COMMANDs.